### PR TITLE
Fix frequency property typo

### DIFF
--- a/main.prg
+++ b/main.prg
@@ -512,7 +512,7 @@ ENDDEFINE
 ******************************
 DEFINE CLASS _words as Custom
     words      = ""
-    frecuency  = 0
+    frequency  = 0
     COUNT      = 0
     lemma      = ""
     count_lemm = 0


### PR DESCRIPTION
## Summary
- fix a typo in `_words` class property

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840665fd4f88320a2971614f33c494a