### PR TITLE
Fix variable for word frequency lookup

### DIFF
--- a/main.prg
+++ b/main.prg
@@ -84,10 +84,10 @@ IF oClasters.append_data()
                 LOOP
             ENDIF
             SELECT words
-            IF SEEK(m.cWords)
+            IF SEEK(cWords)
                 aStatus[countStatus] = STR(words.frequency) + words.lemma
             endif
-        ENDFOR 
+        ENDFOR
         ASORT(aStatus,1,ALEN(aStatus),1)
         * удаляю дубликаты слов в строке
         m.nStatus = aStatus[1]


### PR DESCRIPTION
## Summary
- fix incorrect variable used for frequency lookup in clustering logic

## Testing
- `pre-commit` *(fails: no tests configured)*

------
https://chatgpt.com/codex/tasks/task_e_684064cdbc588320ab27b8d44c0298c3